### PR TITLE
fix: make sure that endpoint has been initialized with a string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ function init(element, options) {
 
   render(<App {...options} />, element)
 
-  if (options.endpoint) {
+  if (options.endpoint.type === 'string') {
     navigate(options.endpoint, options)
   }
 }


### PR DESCRIPTION
Fix to prevent "Not Found" error when data-endpoint is set to empty and an attribute option is used using declarative syntax.
