### PR TITLE
feat: add a configuration option to scroll to the top of the form

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Properties should be provided in camel-casing **without** the data-prefix, e.g. 
 | | `onLoading` | function | Callback function executed when the client start loading. Does not receives parameters. |
 | | `onLoaded` | function | Callback function executed when the client has loaded. Does not receives parameters. |
 | `data-debug` | `debug` | boolean | When enabled, the debug view will be visible, showing the data recieved from the server. |
+| `data-scroll-to-top` | `scrollToTop` | boolean | When enabled, scrolls the top of the form into the visible area of the browser window after the url has changed. |
 
 ### Styling
 

--- a/src/components/document.js
+++ b/src/components/document.js
@@ -9,10 +9,14 @@ function getHref(resource) {
 
 export default class Document extends Component {
   componentDidUpdate(previousProps, previousState) {
-    if (this.props.config.onUrlChange) {
-      const previous = getHref(previousProps.resource)
-      const current = getHref(this.props.resource)
-      if (previous !== current) {
+    const previous = getHref(previousProps.resource)
+    const current = getHref(this.props.resource)
+    if (previous !== current) {
+      if (this.props.config.scrollToTop) {
+        React.findDOMNode(this).scrollIntoView()
+      }
+
+      if (this.props.config.onUrlChange) {
         const formName = this.props.resource.name
         this.props.config.onUrlChange(current, formName)
       }


### PR DESCRIPTION
Add a configuration option to scroll to the top of the form after the url has changed
