### PR TITLE
fix: check if node being clicked is the current to not call api.navigate

### DIFF
--- a/src/components/elements/link.js
+++ b/src/components/elements/link.js
@@ -13,7 +13,7 @@ export default ({ api, className, property }) => (
       if (!e.metaKey &&
       !e.ctrlKey &&
       !property.links.navigate.target) {
-        if  (!property.links.navigate.current) {
+        if (!property.links.navigate.current) {
           api.navigate(property.links.navigate.href)
         }
         e.preventDefault()

--- a/src/components/elements/link.js
+++ b/src/components/elements/link.js
@@ -13,7 +13,9 @@ export default ({ api, className, property }) => (
       if (!e.metaKey &&
       !e.ctrlKey &&
       !property.links.navigate.target) {
-        api.navigate(property.links.navigate.href)
+        if  (!property.links.navigate.current) {
+          api.navigate(property.links.navigate.href)
+        }
         e.preventDefault()
       }
     }}>


### PR DESCRIPTION
Check if node being clicked is the current to not call api.navigate