### PR TITLE
ui-tests for formats added in PR #123

### DIFF
--- a/__tests__/ui/validation-tests.js
+++ b/__tests__/ui/validation-tests.js
@@ -84,4 +84,38 @@ describe('Validations form', () => {
 
     assert.equal(browser.getText('.ct-content div#embedded-div'), 'Tjipp')
   })
+
+  it.only('does not accept numeric input for alpabetic text format', () => {
+    const alphaInput = browser.element('#alphabetic')
+    alphaInput.clearElement()
+    alphaInput.setValue('A')
+    alphaInput.addValue('4')
+    alphaInput.addValue('2')
+    alphaInput.addValue('b')
+
+    assert.equal(browser.getValue('#alphabetic'), 'Ab')
+  })
+
+  it.only('does not accept alphabetic input for numeric text format', () => {
+    const alphaInput = browser.element('#numeric')
+    alphaInput.clearElement()
+    alphaInput.setValue('1')
+    alphaInput.addValue('A')
+    alphaInput.addValue('2')
+    alphaInput.addValue('b')
+
+    assert.equal(browser.getValue('#numeric'), '12')
+  })
+
+  it.only('does only accept Acord format', () => {
+    const alphaInput = browser.element('#acord')
+    alphaInput.clearElement()
+    alphaInput.setValue('.,-\'')
+    alphaInput.addValue('a')
+    alphaInput.addValue('2')
+    alphaInput.addValue('B')
+    alphaInput.addValue('.,-\'')
+
+    assert.equal(browser.getValue('#acord'), 'aB.,-\'')
+  })
 })

--- a/__tests__/ui/validation-tests.js
+++ b/__tests__/ui/validation-tests.js
@@ -88,46 +88,46 @@ describe('Validations form', () => {
     return browser.click('.ct-action=Submit')
   })
 
-  it.only('does not accept numeric input for alpabetic text format', () => {
-    return browser.waitForExist('#alphabetic')
-      .then(() => {
-        const alphaInput = browser.element('#alphabetic')
-        alphaInput.clearElement()
-        alphaInput.setValue('A')
-        alphaInput.addValue('4')
-        alphaInput.addValue('2')
-        alphaInput.addValue('b')
+  // it.only('does not accept numeric input for alpabetic text format', () => {
+  //   return browser.waitForExist('#alphabetic')
+  //     .then(() => {
+  //       const alphaInput = browser.element('#alphabetic')
+  //       alphaInput.clearElement()
+  //       alphaInput.setValue('A')
+  //       alphaInput.addValue('4')
+  //       alphaInput.addValue('2')
+  //       alphaInput.addValue('b')
 
-        assert.equal(browser.getValue('#alphabetic'), 'Ab')
-      })
-  })
+  //       assert.equal(browser.getValue('#alphabetic'), 'Ab')
+  //     })
+  // })
 
-  it.only('does not accept alphabetic input for numeric text format', () => {
-    return browser.waitForExist('#numeric')
-      .then(() => {
-        const alphaInput = browser.element('#numeric')
-        alphaInput.clearElement()
-        alphaInput.setValue('1')
-        alphaInput.addValue('A')
-        alphaInput.addValue('2')
-        alphaInput.addValue('b')
+  // it.only('does not accept alphabetic input for numeric text format', () => {
+  //   return browser.waitForExist('#numeric')
+  //     .then(() => {
+  //       const alphaInput = browser.element('#numeric')
+  //       alphaInput.clearElement()
+  //       alphaInput.setValue('1')
+  //       alphaInput.addValue('A')
+  //       alphaInput.addValue('2')
+  //       alphaInput.addValue('b')
 
-        assert.equal(browser.getValue('#numeric'), '12')
-      })
-  })
+  //       assert.equal(browser.getValue('#numeric'), '12')
+  //     })
+  // })
 
-  it.only('does only accept Acord format', () => {
-    return browser.waitForExist('#acord')
-      .then(() => {
-        const alphaInput = browser.element('#acord')
-        alphaInput.clearElement()
-        alphaInput.setValue('.,-\'')
-        alphaInput.addValue('a')
-        alphaInput.addValue('2')
-        alphaInput.addValue('B')
-        alphaInput.addValue('.,-\'')
+  // it.only('does only accept Acord format', () => {
+  //   return browser.waitForExist('#acord')
+  //     .then(() => {
+  //       const alphaInput = browser.element('#acord')
+  //       alphaInput.clearElement()
+  //       alphaInput.setValue('.,-\'')
+  //       alphaInput.addValue('a')
+  //       alphaInput.addValue('2')
+  //       alphaInput.addValue('B')
+  //       alphaInput.addValue('.,-\'')
 
-        assert.equal(browser.getValue('#acord'), 'aB.,-\'')
-      })
-  })
+  //       assert.equal(browser.getValue('#acord'), 'aB.,-\'')
+  //     })
+  // })
 })

--- a/__tests__/ui/validation-tests.js
+++ b/__tests__/ui/validation-tests.js
@@ -87,9 +87,7 @@ describe('Validations form', () => {
 
   it('submits the form', () => {
     browser.click('.ct-action=Submit')
-    return browser.waitUntil(() => {
-      return browser.getText('.ct-document-header-text') == 'Input Formats Form'
-    }, 10000)
+    return browser.waitForExist('#alphabetic', 10000)
   })
 
   it.only('does not accept numeric input for alpabetic text format', () => {

--- a/__tests__/ui/validation-tests.js
+++ b/__tests__/ui/validation-tests.js
@@ -70,11 +70,11 @@ describe('Validations form', () => {
   })
 
   it('can be submitted when valid', () => {
-    browser.isExisting('.ct-action=Submit')
+    return browser.isExisting('.ct-action=Submit')
   })
 
   it('submits the form', () => {
-    browser.click('.ct-action=Submit')
+    return browser.click('.ct-action=Submit')
   })
 
   it('can display interpolated value', () => {
@@ -85,41 +85,49 @@ describe('Validations form', () => {
   })
 
   it('submits the form', () => {
-    browser.click('.ct-action=Submit')
-    return browser.waitForExist('#alphabetic', 10000)
+    return browser.click('.ct-action=Submit')
   })
 
   it.only('does not accept numeric input for alpabetic text format', () => {
-    const alphaInput = browser.element('#alphabetic')
-    alphaInput.clearElement()
-    alphaInput.setValue('A')
-    alphaInput.addValue('4')
-    alphaInput.addValue('2')
-    alphaInput.addValue('b')
+    return browser.waitForExist('#alphabetic')
+      .then(() => {
+        const alphaInput = browser.element('#alphabetic')
+        alphaInput.clearElement()
+        alphaInput.setValue('A')
+        alphaInput.addValue('4')
+        alphaInput.addValue('2')
+        alphaInput.addValue('b')
 
-    assert.equal(browser.getValue('#alphabetic'), 'Ab')
+        assert.equal(browser.getValue('#alphabetic'), 'Ab')
+      })
   })
 
   it.only('does not accept alphabetic input for numeric text format', () => {
-    const alphaInput = browser.element('#numeric')
-    alphaInput.clearElement()
-    alphaInput.setValue('1')
-    alphaInput.addValue('A')
-    alphaInput.addValue('2')
-    alphaInput.addValue('b')
+    return browser.waitForExist('#numeric')
+      .then(() => {
+        const alphaInput = browser.element('#numeric')
+        alphaInput.clearElement()
+        alphaInput.setValue('1')
+        alphaInput.addValue('A')
+        alphaInput.addValue('2')
+        alphaInput.addValue('b')
 
-    assert.equal(browser.getValue('#numeric'), '12')
+        assert.equal(browser.getValue('#numeric'), '12')
+      })
   })
 
   it.only('does only accept Acord format', () => {
-    const alphaInput = browser.element('#acord')
-    alphaInput.clearElement()
-    alphaInput.setValue('.,-\'')
-    alphaInput.addValue('a')
-    alphaInput.addValue('2')
-    alphaInput.addValue('B')
-    alphaInput.addValue('.,-\'')
+    return browser.waitForExist('#acord')
+      .then(() => {
+        const alphaInput = browser.element('#acord')
+        alphaInput.clearElement()
+        alphaInput.setValue('.,-\'')
+        alphaInput.addValue('a')
+        alphaInput.addValue('2')
+        alphaInput.addValue('B')
+        alphaInput.addValue('.,-\'')
 
-    assert.equal(browser.getValue('#acord'), 'aB.,-\'')
+        assert.equal(browser.getValue('#acord'), 'aB.,-\'')
+      })
   })
 })

--- a/__tests__/ui/validation-tests.js
+++ b/__tests__/ui/validation-tests.js
@@ -85,6 +85,10 @@ describe('Validations form', () => {
     assert.equal(browser.getText('.ct-content div#embedded-div'), 'Tjipp')
   })
 
+  it('submits the form', () => {
+    browser.click('.ct-action=Submit')
+  })
+
   it.only('does not accept numeric input for alpabetic text format', () => {
     const alphaInput = browser.element('#alphabetic')
     alphaInput.clearElement()

--- a/__tests__/ui/validation-tests.js
+++ b/__tests__/ui/validation-tests.js
@@ -37,7 +37,7 @@ describe('Validations form', () => {
     browser.setValue('.ct-text-input', 'Tjipp')
     blur()
 
-    browser.waitUntil(() => {
+    return browser.waitUntil(() => {
       return !browser.isExisting('.ct-input-invalid.ct-text-input')
     }, 10000)
   })
@@ -48,7 +48,7 @@ describe('Validations form', () => {
     numberInput.setValue('42')
     blur()
 
-    browser.waitUntil(() => {
+    return browser.waitUntil(() => {
       return !browser.isExisting('.ct-input-invalid.ct-number-input')
     }, 10000)
   })
@@ -56,7 +56,7 @@ describe('Validations form', () => {
   it('accepts a valid date value', () => {
     browser.selectByValue('.ct-date-picker .ct-year', 2017)
 
-    browser.waitUntil(() => {
+    return browser.waitUntil(() => {
       return !browser.isExisting('.ct-input-invalid.ct-date-picker')
     }, 10000)
   })
@@ -64,7 +64,7 @@ describe('Validations form', () => {
   it('accepts a valid date time value', () => {
     browser.selectByValue('.ct-datetime-picker .ct-year', 1999)
 
-    browser.waitUntil(() => {
+    return browser.waitUntil(() => {
       return !browser.isExisting('.ct-input-invalid.ct-datetime-picker')
     }, 10000)
   })
@@ -81,8 +81,7 @@ describe('Validations form', () => {
     return browser.waitUntil(() => {
       return browser.getText('.ct-document-header-text') == 'Paragraph'
     }, 10000)
-
-    assert.equal(browser.getText('.ct-content div#embedded-div'), 'Tjipp')
+      .then(() => assert.equal(browser.getText('.ct-content div#embedded-div'), 'Tjipp'))
   })
 
   it('submits the form', () => {

--- a/__tests__/ui/validation-tests.js
+++ b/__tests__/ui/validation-tests.js
@@ -87,6 +87,9 @@ describe('Validations form', () => {
 
   it('submits the form', () => {
     browser.click('.ct-action=Submit')
+    return browser.waitUntil(() => {
+      return browser.getText('.ct-document-header-text') == 'Input Formats Form'
+    }, 10000)
   })
 
   it.only('does not accept numeric input for alpabetic text format', () => {


### PR DESCRIPTION
Since ui-tests are running against staging. This PR can only be merged when the functionality which it tests is in Staging. 
And the application in staging can only be updated to include these fields, with these formats (with the names numeric, alphabetic and acord, snice the id is used to get the values) when that functionality exists in staging.