### PR TITLE
fix: set boolean list default if null

### DIFF
--- a/src/components/elements/inputs/boolean-list.js
+++ b/src/components/elements/inputs/boolean-list.js
@@ -1,6 +1,10 @@
 import cx from 'classnames'
 
 export default ({ className, errors, onCommit, property, value }) => {
+  if (value == null) {
+    value = []
+  }
+
   function getValue(checked, newValue) {
     if (!property.isArray) {
       return newValue


### PR DESCRIPTION
fix issue #126 When the client fails to render a form, further calls to navigate() fail bug